### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
     auto-assign:
+        permissions:
+            issues: write
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/xfiles/security/code-scanning/3](https://github.com/gioxx/xfiles/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow interacts with issues (assigning them), it requires `issues: write` permission. We will set this permission at the job level to limit its scope to the `auto-assign` job. All other permissions will default to `none`, ensuring minimal access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
