### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/RepoCommitCounter.yml
+++ b/.github/workflows/RepoCommitCounter.yml
@@ -1,4 +1,6 @@
 name: NoAds Commit Counter
+permissions:
+  contents: write
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/xfiles/security/code-scanning/1](https://github.com/gioxx/xfiles/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. The workflow needs `contents: write` permission to push changes back to the repository and `contents: read` for other operations like checking out the repository. By explicitly setting these permissions, we ensure the workflow has only the necessary access.

The `permissions` block will be added at the root level of the workflow, applying to all jobs. This ensures consistency and avoids redundant definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
